### PR TITLE
fix prevent oar020 for paths ending with params and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.6] - 2025-12-31
+## [1.2.6] - 2026-01-02
 
 ### Fixed
     - OAR019 - SelectParameterCheck
+    - OAR020 - ExpandParameterCheck
 
 ## [1.2.5] - 2025-12-31
 

--- a/src/main/java/apiaddicts/sonar/openapi/checks/parameters/OAR020ExpandParameterCheck.java
+++ b/src/main/java/apiaddicts/sonar/openapi/checks/parameters/OAR020ExpandParameterCheck.java
@@ -14,7 +14,7 @@ public class OAR020ExpandParameterCheck extends AbstractQueryParameterCheck {
             KEY,
             MESSAGE,
             PARAM_NAME,
-            true
+            false
         );
     }
 

--- a/src/test/java/apiaddicts/sonar/openapi/checks/parameters/OAR020ExpandParameterCheckTest.java
+++ b/src/test/java/apiaddicts/sonar/openapi/checks/parameters/OAR020ExpandParameterCheckTest.java
@@ -40,6 +40,11 @@ public class OAR020ExpandParameterCheckTest extends BaseCheckTest {
     }
 
     @Test
+    public void verifyInV2PathEndingWithParam() {
+        verifyV3("with-param");
+    }
+
+    @Test
     public void verifyInV3() {
         verifyV3("plain2");
     }
@@ -57,6 +62,11 @@ public class OAR020ExpandParameterCheckTest extends BaseCheckTest {
     @Test
     public void verifyInV3WithRef() {
         verifyV3("with-ref");
+    }
+
+    @Test
+    public void verifyInV3PathEndingWithParam() {
+        verifyV3("with-param");
     }
 
     @Override

--- a/src/test/resources/checks/v2/parameters/OAR020/with-param.json
+++ b/src/test/resources/checks/v2/parameters/OAR020/with-param.json
@@ -1,0 +1,27 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Swagger Petstore",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/examples/{id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/examples/{id}/items/{id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/checks/v2/parameters/OAR020/with-param.yaml
+++ b/src/test/resources/checks/v2/parameters/OAR020/with-param.yaml
@@ -1,0 +1,15 @@
+swagger: "2.0"
+info:
+  title: Swagger Petstore
+  version: "1.0.0"
+paths:
+  /examples/{id}:
+    get:
+      responses:
+        200:
+          description: OK
+  /examples/{id}/items/{id}:
+    get:
+      responses:
+        200:
+          description: OK

--- a/src/test/resources/checks/v3/parameters/OAR020/with-param.json
+++ b/src/test/resources/checks/v3/parameters/OAR020/with-param.json
@@ -1,0 +1,27 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Swagger Petstore",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/examples/{id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/examples/{id}/items/{id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/checks/v3/parameters/OAR020/with-param.yaml
+++ b/src/test/resources/checks/v3/parameters/OAR020/with-param.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.0
+info:
+  title: Swagger Petstore
+  version: 1.0.0
+paths:
+  /examples/{id}:
+    get:
+      responses:
+        '200':
+          description: OK
+  /examples/{id}/items/{id}:
+    get:
+      responses:
+        '200':
+          description: OK


### PR DESCRIPTION
Prevent OAR020 from triggering on paths ending with path parameters (e.g. {id})

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

Issue Number: #58 