### PR TITLE
fix: serve external $ref fixtures from a local HTTP server in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.6] - 2026-05-05
+
+### Fixed
+    - External `$ref` tests no longer require outbound internet access. Fixtures
+      are now served by a local HTTP server (`ExternalRefHttpServer`) on
+      `http://localhost:18089`, started in `BaseCheckTest`. Affected tests:
+      OAR031 (v2/v3), OAR094, OAR068, OAR086.
+
 ## [1.3.5] - 2026-04-08
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apiaddicts.apitools.dosonarapi</groupId>
   <artifactId>sonaropenapi-rules-community</artifactId>
-  <version>1.3.5</version>
+  <version>1.3.6</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube OpenAPI Community Rules</name>

--- a/src/test/java/apiaddicts/sonar/openapi/BaseCheckTest.java
+++ b/src/test/java/apiaddicts/sonar/openapi/BaseCheckTest.java
@@ -8,6 +8,8 @@ import org.sonar.api.server.rule.RulesDefinition;
 
 import org.apiaddicts.apitools.dosonarapi.api.OpenApiCheck;
 
+import apiaddicts.sonar.openapi.utils.ExternalRefHttpServer;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -77,6 +79,7 @@ public abstract class BaseCheckTest {
 
     @BeforeClass
     public static void beforeClass() {
+        ExternalRefHttpServer.start();
         I18nContext.setLang("en");
         if (repository != null) return;
         OpenAPICustomRulesDefinition rulesDefinition = new OpenAPICustomRulesDefinition();

--- a/src/test/java/apiaddicts/sonar/openapi/utils/ExternalRefHttpServer.java
+++ b/src/test/java/apiaddicts/sonar/openapi/utils/ExternalRefHttpServer.java
@@ -1,0 +1,59 @@
+package apiaddicts.sonar.openapi.utils;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+public final class ExternalRefHttpServer {
+
+    public static final int PORT = 18089;
+    public static final String BASE_URL = "http://localhost:" + PORT;
+
+    private static final Path FIXTURES = Paths.get("src", "test", "resources", "externalRef").toAbsolutePath().normalize();
+
+    private static HttpServer server;
+
+    private ExternalRefHttpServer() {
+    }
+
+    public static synchronized void start() {
+        if (server != null) {
+            return;
+        }
+        try {
+            HttpServer s = HttpServer.create(new InetSocketAddress("127.0.0.1", PORT), 0);
+            s.createContext("/", ExternalRefHttpServer::handle);
+            s.setExecutor(null);
+            s.start();
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> s.stop(0)));
+            server = s;
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not start external ref HTTP server on port " + PORT, e);
+        }
+    }
+
+    private static void handle(HttpExchange exchange) throws IOException {
+        try {
+            String name = exchange.getRequestURI().getPath().replaceFirst("^/+", "");
+            Path file = FIXTURES.resolve(name).normalize();
+            if (!file.startsWith(FIXTURES) || !Files.isRegularFile(file)) {
+                exchange.sendResponseHeaders(404, -1);
+                return;
+            }
+            byte[] body = Files.readAllBytes(file);
+            exchange.getResponseHeaders().set("Content-Type", "application/yaml; charset=utf-8");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        } finally {
+            exchange.close();
+        }
+    }
+}

--- a/src/test/resources/checks/v2/examples/OAR031/externalref.yaml
+++ b/src/test/resources/checks/v2/examples/OAR031/externalref.yaml
@@ -18,7 +18,7 @@ paths:
               $ref: '#/definitions/User'
         400:
           $ref: >- # Noncompliant {{OAR031: Responses must have one or more examples defined}}
-            https://raw.githubusercontent.com/apiaddicts/sonaropenapi-rules/refs/heads/master/src/test/resources/externalRef/OAR031.yaml#/components/responses/server_error_response
+            http://localhost:18089/OAR031.yaml#/components/responses/server_error_response
   /users/{userId}:
     get:
       parameters:

--- a/src/test/resources/checks/v3/examples/OAR031/externalref.yaml
+++ b/src/test/resources/checks/v3/examples/OAR031/externalref.yaml
@@ -24,7 +24,7 @@ paths:
                   $ref: '#/components/schemas/User'
         '400':
           $ref: >- # Noncompliant {{OAR031: Responses must have one or more examples defined}}
-            https://raw.githubusercontent.com/apiaddicts/sonaropenapi-rules/refs/heads/master/src/test/resources/externalRef/OAR031.yaml#/components/responses/server_error_response
+            http://localhost:18089/OAR031.yaml#/components/responses/server_error_response
   /users/{userId}:
     get:
       summary: Get a user by ID
@@ -48,7 +48,7 @@ paths:
                 $ref: '#/components/schemas/User'
         '400':
           $ref: >- # Noncompliant {{OAR031: Responses must have one or more examples defined}}
-            https://raw.githubusercontent.com/apiaddicts/sonaropenapi-rules/refs/heads/master/src/test/resources/externalRef/OAR031.yaml#/components/responses/server_error_response
+            http://localhost:18089/OAR031.yaml#/components/responses/server_error_response
 components:
   schemas:
     User:

--- a/src/test/resources/checks/v3/examples/OAR094/externalref.yaml
+++ b/src/test/resources/checks/v3/examples/OAR094/externalref.yaml
@@ -36,7 +36,7 @@ paths:
             application/json:
               schema:
                 $ref: >- # Noncompliant {{OAR094: It is recommended to use examples instead of example as some tools like microcks use this section of the definition}}
-                  https://raw.githubusercontent.com/apiaddicts/sonaropenapi-rules/refs/heads/master/src/test/resources/externalRef/OAR094.yaml#/components/schemas/Pet
+                  http://localhost:18089/OAR094.yaml#/components/schemas/Pet
         '400':
           description: Bad Request.
           headers:
@@ -48,7 +48,7 @@ paths:
             application/json:
               schema:
                 $ref: >- # Noncompliant {{OAR094: It is recommended to use examples instead of example as some tools like microcks use this section of the definition}}
-                  https://raw.githubusercontent.com/apiaddicts/sonaropenapi-rules/refs/heads/master/src/test/resources/externalRef/OAR094.yaml#/components/schemas/ErrorMessage
+                  http://localhost:18089/OAR094.yaml#/components/schemas/ErrorMessage
               example:  # Noncompliant {{OAR094: It is recommended to use examples instead of example as some tools like microcks use this section of the definition}}
                 error:
                   status: '400'

--- a/src/test/resources/checks/v3/format/OAR068/externalref.yaml
+++ b/src/test/resources/checks/v3/format/OAR068/externalref.yaml
@@ -36,7 +36,7 @@ paths:
             application/json:
               schema: # Noncompliant {{OAR068: RequestBody and Responses schema property names must be compliant with the PascalCase naming convention}}
                 $ref: >-
-                  https://raw.githubusercontent.com/apiaddicts/sonaropenapi-rules/refs/heads/master/src/test/resources/externalRef/OAR068.yaml#/components/schemas/datosUsuario
+                  http://localhost:18089/OAR068.yaml#/components/schemas/datosUsuario
         '400':
           description: Bad Request.
           headers:
@@ -48,7 +48,7 @@ paths:
             application/json:
               schema: # Noncompliant {{OAR068: RequestBody and Responses schema property names must be compliant with the PascalCase naming convention}}
                 $ref: >-
-                  https://raw.githubusercontent.com/apiaddicts/sonaropenapi-rules/refs/heads/master/src/test/resources/externalRef/OAR086.yaml#/components/schemas/ErrorMessage
+                  http://localhost:18089/OAR086.yaml#/components/schemas/ErrorMessage
               example:  
                 error:
                   status: '400'

--- a/src/test/resources/checks/v3/format/OAR086/external-refexample.yaml
+++ b/src/test/resources/checks/v3/format/OAR086/external-refexample.yaml
@@ -36,7 +36,7 @@ paths:
             application/json:
               schema:              
                 $ref: >- # Noncompliant {{OAR086: Descriptions must begin with a capital letter, end with a period and not be empty}}
-                  https://raw.githubusercontent.com/apiaddicts/sonaropenapi-rules/refs/heads/master/src/test/resources/externalRef/OAR086.yaml#/components/schemas/datosUsuario
+                  http://localhost:18089/OAR086.yaml#/components/schemas/datosUsuario
         '400':
           description: Bad Request.
           headers:
@@ -48,7 +48,7 @@ paths:
             application/json:
               schema:
                 $ref: >- # Noncompliant {{OAR086: Descriptions must begin with a capital letter, end with a period and not be empty}}
-                  https://raw.githubusercontent.com/apiaddicts/sonaropenapi-rules/refs/heads/master/src/test/resources/externalRef/OAR086.yaml#/components/schemas/ErrorMessage
+                  http://localhost:18089/OAR086.yaml#/components/schemas/ErrorMessage
               example:
                 error:
                   status: '400'


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Several external `$ref` tests resolve their references against `https://raw.githubusercontent.com/apiaddicts/sonaropenapi-rules/...`. This forces the test suite to make outbound HTTPS calls to GitHub during `mvn test`, which fails in restricted or offline environments (corporate networks, CI runners without egress, air-gapped setups) and also makes the tests dependent on the availability of GitHub and on the contents of the `master` branch at test time.

Affected tests: OAR031 (v2 and v3), OAR094, OAR068, OAR086.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added a new test utility `ExternalRefHttpServer` that starts a lightweight in-process HTTP server on `http://localhost:18089`, serving the YAML files under `src/test/resources/externalRef/`.
- `BaseCheckTest.beforeClass` starts the server once for the test suite, so all checks resolving external `$ref`s do it against localhost` instead of the public internet.
- Updated the affected fixtures (OAR031 v2/v3, OAR094, OAR068, OAR086) to point to `http://localhost:18089/<file>.yaml` instead of the `raw.githubusercontent.com` URLs.
- Bumped version to `1.3.6` in `pom.xml` and added the corresponding entry to `CHANGELOG.md`.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

- The fixture files under `src/test/resources/externalRef/` are unchanged; only the URLs that reference them have been switched to `localhost`.
- The HTTP server binds to `127.0.0.1` only and is shut down via a JVM shutdown hook, so it does not leak between builds.
- No production code is modified — changes are scoped to the test suite, the version bump and the changelog.
